### PR TITLE
Fix missing hyphens on model name

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ We slightly change their configs and tokenizers. Please use our setting to run t
 <div align="center">
 
 
-| Category | Benchmark (Metric) | Claude-3.5-Sonnet-1022 | GPT-4o 0513 | DeepSeek V3 | OpenAI o1-mini | OpenAI o1-1217 | DeepSeek R1 |
+| Category | Benchmark (Metric) | Claude-3.5-Sonnet-1022 | GPT-4o 0513 | DeepSeek-V3 | OpenAI o1-mini | OpenAI o1-1217 | DeepSeek-R1 |
 |----------|-------------------|----------------------|------------|--------------|----------------|------------|--------------|
 | | Architecture | - | - | MoE | - | - | MoE |
 | | # Activated Params | - | - | 37B | - | - | 37B |


### PR DESCRIPTION
The typo is in the Evaluation Results table where the model names "DeepSeek V3" and "DeepSeek R1" are missing hyphens. They should be written as "DeepSeek-V3" and "DeepSeek-R1" to match the official naming conventions used throughout the document and in the model repositories.

Correction:

In the table under the "Model" column:

Change "DeepSeek V3" → "DeepSeek-V3"

Change "DeepSeek R1" → "DeepSeek-R1"

This ensures consistency with the hyphenated model names used elsewhere (e.g., "DeepSeek-R1-Zero", "DeepSeek-R1-Distill-Qwen-32B").