### PR TITLE
docs: add vLLM new feature(>-v0.7.1) supporting DeepSeek-R1

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ For instance, you can easily start a service using [vLLM](https://github.com/vll
 ```shell
 vllm serve deepseek-ai/DeepSeek-R1-Distill-Qwen-32B --tensor-parallel-size 2 --max-model-len 32768 --enforce-eager
 ```
+With `vllm` >= v0.7.1, you can additionally append `--enable-reasoning --reasoning-parser deepseek_r1` to above shell command, for reasoning output parsing.
+
 
 You can also easily start a service using [SGLang](https://github.com/sgl-project/sglang)
 


### PR DESCRIPTION
refer to vLLM documents:
 
https://github.com/vllm-project/vllm/blob/main/docs/source/features/reasoning_outputs.md?plain=1#L21

and

https://github.com/vllm-project/vllm/releases/tag/v0.7.1

we can add arguments for vLLM serving.