### PR TITLE
Update README.md:  fixed --tp which is invalid is launch option

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ vllm serve deepseek-ai/DeepSeek-R1-Distill-Qwen-32B --tensor-parallel-size 2 --m
 You can also easily start a service using [SGLang](https://github.com/sgl-project/sglang)
 
 ```bash
-python3 -m sglang.launch_server --model deepseek-ai/DeepSeek-R1-Distill-Qwen-32B --trust-remote-code --tp 2
+python3 -m sglang.launch_server --model deepseek-ai/DeepSeek-R1-Distill-Qwen-32B --trust-remote-code --tensor-parallel-size 2
 ```
 
 ### Usage Recommendations


### PR DESCRIPTION
Hi,
As  https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/server_args.py at line 497 and next, --tp is not a valid command option.

Possible values --tensor-parallel-size or --tp-size

I chose --tensor-parallel-size to remain consistent with previous command suggested by this README